### PR TITLE
Add "Copy Code" Option in Hover Feature

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,8 +132,6 @@ export function activate(context: vscode.ExtensionContext) {
       provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken) {
         let fullExpression = '';
         let currentLine = position.line;
-        console.log("=-------------currentLine-------",currentLine)
-
         while (currentLine < document.lineCount) {
           const lineText = document.lineAt(currentLine).text.trim();
           if (token.isCancellationRequested) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,13 +132,13 @@ export function activate(context: vscode.ExtensionContext) {
       provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken) {
         let fullExpression = '';
         let currentLine = position.line;
+        console.log("=-------------currentLine-------",currentLine)
 
         while (currentLine < document.lineCount) {
           const lineText = document.lineAt(currentLine).text.trim();
           if (token.isCancellationRequested) {
             return null;
           }
-
           fullExpression += ` ${lineText}`;
           if (lineText.endsWith(';') || lineText.endsWith('}') || currentLine === document.lineCount - 1) break;
           currentLine++;
@@ -155,10 +155,14 @@ export function activate(context: vscode.ExtensionContext) {
         if (isTernary(fullExpression)) {
           try {
             const ifElse = convertToIfElse(fullExpression);
-            return new vscode.Hover({
-              language: 'typescript',
-              value: ifElse,
-            });
+            // Create Markdown content with a Copy button
+            const markdownContent = new vscode.MarkdownString();
+            markdownContent.isTrusted = true; // Allow the use of commands in the hover content
+
+            markdownContent.appendCodeblock(ifElse, 'typescript'); // Add the converted if-else code
+            markdownContent.appendMarkdown(`\n\n[Copy](command:extension.copyToClipboard?${encodeURIComponent(JSON.stringify(ifElse))})`); // Add a "Copy" button with a custom command
+            return new vscode.Hover(markdownContent);
+        
           } catch (error) {
             console.error('Error converting ternary:', error);
           }
@@ -168,7 +172,19 @@ export function activate(context: vscode.ExtensionContext) {
       }
     }
   );
-  context.subscriptions.push(hoverProvider);
+  context.subscriptions.push(hoverProvider, copyCommand);
 }
+
+
+  // Register the copy command
+  const copyCommand = vscode.commands.registerCommand('extension.copyToClipboard', async (text: string) => {
+    try {
+      await vscode.env.clipboard.writeText(text); // Copy text to the clipboard
+      vscode.window.showInformationMessage('Copied to clipboard!'); // Notify the user
+    } catch (error) {
+      vscode.window.showErrorMessage('Failed to copy to clipboard.');
+      console.error(error);
+    }
+  });
 
 export function deactivate() { }


### PR DESCRIPTION
**This Pull Request introduces a new "Copy Code" feature to the VS Code extension that allows users to easily copy the transformed if-else code directly from the hover preview.**

![image](https://github.com/user-attachments/assets/183f93d5-38d3-43a2-b503-9fd84c3711dd)
![image](https://github.com/user-attachments/assets/3aea62d5-9022-4977-b09b-9371d1ce8d4c)
![image](https://github.com/user-attachments/assets/2c93d6c1-5f92-4f5e-b9ba-024e39e60001)
![image](https://github.com/user-attachments/assets/2171634b-243e-4449-baf5-257fc7f6b5a9)
